### PR TITLE
Use awk and JQ instead to allow for spaces in e.g. app names

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -3,27 +3,58 @@
 # References:
 # - https://nikitabobko.github.io/AeroSpace/commands#list-windows
 # - https://www.alfredapp.com/help/workflows/inputs/script-filter/json/
-result=$( \
-  aerospace list-windows --workspace visible --format "%{app-pid} %{window-id} %{app-name} %{window-title}" | \
-  while read -r appPid windowId appName windowTitle; \
-  do 
-    appPath="$(ps -o comm= -p "$appPid")"
-    bundlePath="${appPath%%\.app*}.app"
 
-    echo "{ 
-      \"title\": \"$appName\", 
-      \"subtitle\": $(echo "$windowTitle" | jq -Rsa .),
-      \"match\": $(echo "$appName | $windowTitle" | jq -Rsa .),
-      \"arg\": \"$windowId\", 
-      \"icon\": { 
-        \"type\": \"fileicon\", 
-        \"path\": \"$bundlePath\" 
-      } 
-    },";
-  done
+AERO_DELIM=":::DELIM:::"
+
+result_json=$( \
+  aerospace list-windows --all --format "%{app-pid}${AERO_DELIM}%{window-id}${AERO_DELIM}%{app-name}${AERO_DELIM}%{window-title}" | \
+  awk -F "${AERO_DELIM}" '{
+    appPid = $1
+    windowId = $2
+    appName = $3
+    windowTitle = $4
+
+    # Get appPath using ps
+    ps_cmd = "ps -o comm= -p " appPid
+    appPath = "" # Default to empty string
+    if ((ps_cmd | getline line) > 0) {
+      appPath = line
+    }
+    close(ps_cmd)
+
+    # Calculate bundlePath
+    bundlePath = appPath
+    # Replicates bash: ${appPath%%\.app*}.app
+    sub(/\.app.*/, "", bundlePath) # Remove .app and anything after
+    bundlePath = bundlePath ".app" # Append .app
+
+    # Output fields separated by NUL, one record per line
+    printf "%s%c%s%c%s%c%s%c%s%c%s\n", appPid, 0, windowId, 0, appName, 0, windowTitle, 0, appPath, 0, bundlePath
+  }' | \
+  jq --raw-input --slurp '
+    # Split the entire input by newlines, then filter out empty lines
+    split("\n")
+    | map(select(length > 0))
+    # For each line, split by NUL character to get fields
+    | map(split("\u0000") | {
+        # Assign fields to an object based on their order from awk
+        # .[0] is appPid, .[1] is windowId, .[2] is appName,
+        # .[3] is windowTitle, .[4] is appPath, .[5] is bundlePath
+        "title": .[2], # appName
+        "subtitle": .[3], # windowTitle
+        "match": (.[2] + " | " + .[3]), # appName | windowTitle
+        "arg": .[1], # windowId
+        "icon": {
+          "type": "fileicon",
+          "path": .[5] # bundlePath
+        }
+      })
+    # Wrap the resulting array of objects into the final structure
+    | {items: .}
+  '
 )
 
-echo "{ \"items\": [ $result ] }"
+echo "$result_json"
 
 if [ -n "$DEBUG" ]; then
   echo ""


### PR DESCRIPTION
Tjena, @yuriteixeira! Long time no see. :) I was delighted to see your Alfred workflow come up in Google search when I was looking for an integration with Aerospace. I noticed that the script couldn't handle spaces in app names very well (they leaked into the window title variable since `read` used spaces as delimiters) so I used `aider` to fix it quickly. 

As I'm writing this, I also remember that I swapped the workspace-specific list behavior to `--all`. 

Take it or leave it. :) Either way, thanks for the workflow. I use it a lot!